### PR TITLE
Fix typo in 309_monitorr.yaml

### DIFF
--- a/components/309-monitorr.yaml
+++ b/components/309-monitorr.yaml
@@ -16,7 +16,7 @@
       - TZ=${TIMEZONE}
       - UMASK_SET=022
     labels:
-      - "omni=${OMBINAME},${MYDOMAIN},yes,yes,yes"
+      - "omni=${MONITORRNAME},${MYDOMAIN},yes,yes,yes"
       - autoheal=true
       - traefik.enable=true
       - traefik.http.routers.monitorr.rule=Host(`${MONITORRNAME}.${MYDOMAIN}`)


### PR DESCRIPTION
Fixed a typo in the omni label for monitorr which was incorrectly set to "ombi"