### PR TITLE
Fix bug in 308_ombi.yaml due to repeated `restart` key

### DIFF
--- a/components/308-ombi.yaml
+++ b/components/308-ombi.yaml
@@ -2,7 +2,6 @@
 # Ombi - Content request and user management
 #
   ombi:
-    restart: always
     image: lscr.io/linuxserver/ombi
     container_name: ${OMBINAME}
     hostname: ${OMBINAME}


### PR DESCRIPTION
Removed extraneous `restart` key and value at the beginning of the service definition which was causing error when component was enabled.